### PR TITLE
make internals accessible

### DIFF
--- a/private/json-hierlist-item-mixin.rkt
+++ b/private/json-hierlist-item-mixin.rkt
@@ -10,12 +10,16 @@
 
 (define (get-color-from-preference name)
   (define pref (get-preference (string->symbol (~a color-key-prefix name))))
-  (apply make-object (cons color% (seventh (hash-ref pref 'classic)))))
+  (and pref (apply make-object (cons color% (seventh (hash-ref pref 'classic))))))
 
 (define (make-style-delta style)
   (define delta (new style-delta%))
+  ; this is called many times
+  ; if this is skipped then nothing renders
+  (define foreground (get-color-from-preference style))
+  (when foreground
+    (send delta set-delta-foreground foreground))
   (send* delta
-    (set-delta-foreground (get-color-from-preference style))
     (set-face (get-preference font-name-key))
     (set-size-add (vector-ref (get-preference font-size-key) 1))
     (set-size-mult 0))

--- a/private/json-hierlist.rkt
+++ b/private/json-hierlist.rkt
@@ -10,7 +10,7 @@
   (class hierarchical-list%
     (init-field [on-item-select values])
     (define node-cache (make-hash))
-    (define root #f)
+    (field [root #f])
     
     (define/private (new-item-node parent)
       (send parent new-item json-hierlist-item-mixin))

--- a/private/json-view.rkt
+++ b/private/json-view.rkt
@@ -4,22 +4,23 @@
          "json-hierlist.rkt"
          "node-data.rkt")
 
-(provide json-view%)
+(provide json-view%
+         (struct-out node-data))
 
 (define json-view%
   (class vertical-panel%
     (super-new)
 
-    (define path-bar (new breadcrumb%
+    (field [path-bar (new breadcrumb%
                           [parent this]
                           [callback (lambda (path)
-                                      (send json-hierlist select-path path))]))
+                                      (send json-hierlist select-path path))])])
 
-    (define json-hierlist (new json-hierlist%
+    (field [json-hierlist (new json-hierlist%
                                [parent this]
                                [on-item-select (lambda (data)
                                                  (send path-bar set-path!
-                                                       (node-data-path data)))]))
+                                                       (node-data-path data)))])])
 
     (define/public (get-json)
       (send json-hierlist get-json))


### PR DESCRIPTION
in order to programatically control the json view a number of
currently private fields need to be public so that e.g. it is possible
to control the layout of the tree and know where/how the user is
interacting with the view

also handle cases where user preferences are not set